### PR TITLE
Fix compilation error and warning from 423e6ef

### DIFF
--- a/Code/Reflow_Master_v2/Reflow_Master_v2.ino
+++ b/Code/Reflow_Master_v2/Reflow_Master_v2.ino
@@ -809,9 +809,8 @@ void ReadCurrentTempAvg()
   }
   else
   {
-    tcError = 0
-    // required by the TC to get the correct compensated value back 
-    float internal = tc.getInternal();
+    tcError = 0;
+    tc.getInternal();   // required by the TC to get the correct compensated value back 
     currentTempAvg += tc.getTemperature() + set.tempOffset;
     avgReadCount++;
   }
@@ -830,8 +829,7 @@ void ReadCurrentTemp()
   else
   {
     tcError = 0;
-    // required by the TC to get the correct compensated value back 
-    float internal = tc.getInternal();
+    tc.getInternal();  // required by the TC to get the correct compensated value back 
     currentTemp = tc.getTemperature() + set.tempOffset;
     currentTemp =  constrain(currentTemp, -10, 350);
 


### PR DESCRIPTION
Following up from #16. The post-merge commit is missing a semicolon on line 812 which breaks compilation.

I didn't realize the `getInternal()` functions were doing anything behind the scenes. They were removed because the allocated value is not used in the function. This change keeps the function calls but removes the allocated variables to fix the warning.